### PR TITLE
Update Discord invite link

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -30,7 +30,7 @@ export default function Footer() {
         <a href="https://ca.linkedin.com/showcase/0xsequence/">
           <Linkedin />
         </a>
-        <a href="https://discord.gg/sequence">
+        <a href="https://discord.com/invite/YnGKP7d3vS">
           <Discord />
         </a>
         <a href="https://github.com/0xsequence">


### PR DESCRIPTION
Updates old Sequence Discord invite links to https://discord.com/invite/YnGKP7d3vS. Validation: searched fresh clones for old discord.gg/sequence, discord.com/invite/sequence, and legacy U69897fH invite forms; no remaining matches in patched repos.